### PR TITLE
Feature/auth

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@types/jasmine": "2.5.36",
     "@types/node": "^6.0.73",
     "angular-in-memory-web-api": "^0.3.2",
+    "angular2-jwt": "^0.2.3",
     "angular2-template-loader": "^0.6.0",
     "awesome-typescript-loader": "^3.0.4",
     "css-loader": "^0.26.1",

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,5 +1,3 @@
 <main>
-	<div *ngIf="resume" class="col-xs-12 col-md-6">		
-  		<div [innerHtml]="content" id="resumeBody"></div>
-	</div>
+	<login></login>
 </main>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,24 +1,32 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule }  from '@angular/platform-browser';
 import { HttpModule } from '@angular/http';
+import { FormsModule } from '@angular/forms';
 
 import { InMemoryWebApiModule } from 'angular-in-memory-web-api';
 import { InMemoryDataService }  from './in-memory-data.service';
 
 import { AppComponent } from './app.component';
+import { LoginComponent } from './component/login/login.component';
+
 import { ResumeService } from './service/resume/resume.service';
+import { AuthService } from './service/auth/auth.service';
+
 
 @NgModule({
   imports: [
     BrowserModule,
     HttpModule,
+    FormsModule,
     InMemoryWebApiModule.forRoot(InMemoryDataService),    
   ],
   declarations: [
-    AppComponent
+    AppComponent,
+    LoginComponent
   ],
   providers: [
-  	ResumeService
+  	ResumeService,
+  	AuthService
   ],
   bootstrap: [ AppComponent ]
 })

--- a/src/app/component/login/login.component.html
+++ b/src/app/component/login/login.component.html
@@ -1,5 +1,3 @@
-<button (click)="loggedIn()">Logged In?</button>
-<button (click)="logout()">Log Out</button>
 <div class="container">
     <h1>Login</h1>
     <form #loginForm="ngForm" (ngSubmit)="onSubmit(emailRef.value, passwordRef.value)">
@@ -25,4 +23,3 @@
       <button type="submit" class="btn btn-success" [disabled]="!loginForm.form.valid">Submit</button>
     </form>
 </div>
-<div *ngIf="data">{{data}}</div>

--- a/src/app/component/login/login.component.html
+++ b/src/app/component/login/login.component.html
@@ -1,0 +1,28 @@
+<button (click)="loggedIn()">Logged In?</button>
+<button (click)="logout()">Log Out</button>
+<div class="container">
+    <h1>Login</h1>
+    <form #loginForm="ngForm" (ngSubmit)="onSubmit(emailRef.value, passwordRef.value)">
+      <div class="form-group">
+        <label for="email">Email</label>
+        <input type="email" class="form-control" id="email" 
+        pattern='^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$'
+        required
+        [(ngModel)]="email" name="email"
+        #emailRef="ngModel"
+        >               
+        <div class="alert alert-danger" [hidden]="emailRef.pristine || emailRef.untouched || emailRef.valid">Please enter a valid Email address</div>
+      </div>      
+      <div class="form-group">
+        <label for="password">Password</label>
+        <input type="password" class="form-control" id="password"
+        required
+        [(ngModel)]="password" name = "password"
+        pattern="^(?=.*[0-9]).{6,}$"
+        #passwordRef="ngModel">
+        <div class="alert">Password must be 6 characters long and must contain at least one number</div>
+      </div>
+      <button type="submit" class="btn btn-success" [disabled]="!loginForm.form.valid">Submit</button>
+    </form>
+</div>
+<div *ngIf="data">{{data}}</div>

--- a/src/app/component/login/login.component.ts
+++ b/src/app/component/login/login.component.ts
@@ -10,7 +10,7 @@ export class LoginComponent {
 
 	email: string;
 	password: string;	
-	data: string;
+	
 	constructor(private auth: AuthService){} 	
 
 	onSubmit(email: string, password: string){

--- a/src/app/component/login/login.component.ts
+++ b/src/app/component/login/login.component.ts
@@ -1,0 +1,32 @@
+import { Component } from '@angular/core';
+
+import { AuthService } from '../../service/auth/auth.service';
+
+@Component({
+	selector: 'login',
+	templateUrl: './login.component.html',
+})
+export class LoginComponent {
+
+	email: string;
+	password: string;	
+	data: string;
+	constructor(private auth: AuthService){} 	
+
+	onSubmit(email: string, password: string){
+		this.auth.login(email, password);
+	}
+
+	loggedIn(): boolean {	
+		if(this.auth.loggedIn()){
+			console.log("logged in");
+			return true;
+		}
+		console.log("not logged in");
+		return false;
+	}
+
+	logout(){
+		this.auth.logout();
+	}
+}

--- a/src/app/service/auth/auth.service.ts
+++ b/src/app/service/auth/auth.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+
+import { tokenNotExpired } from '../../../../node_modules/angular2-jwt/angular2-jwt';
+
+@Injectable()
+export class AuthService{	
+
+	login(username: string, password: string): boolean {		
+		if(username === "username@example.com" && password === "password1"){			
+			localStorage.setItem("token", "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiYWRtaW4iOnRydWV9.TJVA95OrM7E2cBab30RMHrHDcEfxjoYZgeFONFh7HgQ");
+			return true;
+		}
+		return false;
+	}
+
+	logout(){
+		localStorage.removeItem("token");
+	}
+
+	loggedIn(): boolean{
+		return tokenNotExpired();		
+	}
+}

--- a/src/assets/css/styles.css
+++ b/src/assets/css/styles.css
@@ -2,3 +2,10 @@ body {
     background: #ffffff;
     color: #000000;
 }
+
+.ng-valid[required], .ng-valid.required  {
+  border-left: 5px solid #42A948; /* green */
+}
+.ng-invalid:not(form)  {
+  border-left: 5px solid #a94442; /* red */
+}

--- a/src/index.html
+++ b/src/index.html
@@ -7,7 +7,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css" integrity="sha384-BVYiiSIFeK1dGmJRAkycuHAHRg32OmUcww7on3RYdg4Va+PmSTsz/K68vbdEjh4u" crossorigin="anonymous">
     <link rel="shortcut icon" href="/favicon.ico" type="image/x-icon">
-	<link rel="icon" href="/favicon.ico" type="image/x-icon">
+	  <link rel="icon" href="/favicon.ico" type="image/x-icon">    
   </head>
   <body>
     <my-app>Loading...</my-app>


### PR DESCRIPTION
Added a login form and an auth service. 

Logging in requires a valid email and a password of at least length 6 characters and one number (These constraints will need to be reviewed in the future). The submit button will be disabled if these validation checks do not pass. The user will receive feedback if they have not entered a valid value, and a message will display if they enter an invalid email.

The auth service will log the user in by setting a valid jwt in localStorage. This will happen if the auth.service method login() is called with parameters "username@example.com" and "password1". Actual authentication will need to happen on the api back end over https. The jwt does not expire, so the user can only become not logged in if the logout() method in auth.service is called.

auth service also has a method called loggedIn() that will check for an unexpired token. This can be used in the future to prevent views being shown to non logged in users. This could be circumvented by a clever hacker adding any valid jwt to their local storage, but that only gives them access to restricted views, not data. Data on the backend will still be protected by the jwt signature.